### PR TITLE
New coords handler updated to use xyz coordinates

### DIFF
--- a/neuroinfer/code/BayesianAnalysis.py
+++ b/neuroinfer/code/BayesianAnalysis.py
@@ -36,20 +36,12 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
     global_path = os.path.dirname(script_directory)
     results_folder_path = os.path.join(global_path, "results")
     data_path = os.path.join(global_path, "data")  # Path to the saved_result folder
-    #print('Data path: ',data_path)
 
     # Check if results_folder_path exists, if not, create it
     if not os.path.exists(results_folder_path):
-        os.makedirs(results_folder_path)
-
-    # Load mask image   
-    #mask_nifti = image.load_img('.tmp/mask.nii.gz')
-    #affine_inv = np.linalg.inv(mask_nifti.affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
-    
+        os.makedirs(results_folder_path) 
 
     if not pd.isnull(area) and pd.isnull(x_target) and pd.isnull(y_target) and pd.isnull(z_target):
-        # Call run_bayesian_analysis_area if area is not nan and coordinates are nan
-        #results=run_bayesian_analysis_area(cog_list, prior_list, area, radius, result_df, cm)
         mask,affine=generate_nifit_mask(area,atlas_path)
         affine_inv = np.linalg.inv(affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
 
@@ -69,16 +61,7 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
         mask,affine=generate_nifit_mask(1,atlas_path) #area is set to 1 to get the mask at the coordinates
         affine_inv = np.linalg.inv(affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
 
-        
-
-        #dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
-        # Calculate the Euclidean distance from each point to the center of the sphere
-        #mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
-        # Convert MNI coordinates to voxel coordinates for each coordinate
-        #print('lenght mni coordinates',len(mni_coords))
-        #xyz_coords = [coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
         dt_papers_nq, xyz_coords = load_or_calculate_variables(data_path, affine_inv)
-
 
         x_target, y_target, z_target = coord_transform(x_target, y_target, z_target,affine_inv)
         results=run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, radius, result_df, cm,xyz_coords,dt_papers_nq)

--- a/neuroinfer/code/BayesianAnalysis.py
+++ b/neuroinfer/code/BayesianAnalysis.py
@@ -35,6 +35,8 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
     script_directory = os.path.dirname(os.path.abspath(__file__))
     global_path = os.path.dirname(script_directory)
     results_folder_path = os.path.join(global_path, "results")
+    data_path = os.path.join(global_path, "data")  # Path to the saved_result folder
+    #print('Data path: ',data_path)
 
     # Check if results_folder_path exists, if not, create it
     if not os.path.exists(results_folder_path):
@@ -43,7 +45,7 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
     # Load mask image   
     #mask_nifti = image.load_img('.tmp/mask.nii.gz')
     #affine_inv = np.linalg.inv(mask_nifti.affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
-
+    
 
     if not pd.isnull(area) and pd.isnull(x_target) and pd.isnull(y_target) and pd.isnull(z_target):
         # Call run_bayesian_analysis_area if area is not nan and coordinates are nan
@@ -51,7 +53,9 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
         mask,affine=generate_nifit_mask(area,atlas_path)
         affine_inv = np.linalg.inv(affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
 
-        results=run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, result_df,cm)
+        dt_papers_nq, xyz_coords = load_or_calculate_variables(data_path, affine_inv)
+
+        results=run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, result_df,cm,dt_papers_nq,xyz_coords)
 
         # Save results_dict to a pickle file
         file_path = os.path.join(results_folder_path, f"results_area_cm_{cm}_{area}_{cog_list}.pkl")
@@ -65,15 +69,15 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
         mask,affine=generate_nifit_mask(1,atlas_path) #area is set to 1 to get the mask at the coordinates
         affine_inv = np.linalg.inv(affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
 
-        data_path = os.path.join(global_path, "data")  # Path to the saved_result folder
-        print('Data path: ',data_path)
+        
 
-        dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
+        #dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
         # Calculate the Euclidean distance from each point to the center of the sphere
-        mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
+        #mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
         # Convert MNI coordinates to voxel coordinates for each coordinate
-        print('lenght mni coordinates',len(mni_coords))
-        xyz_coords = [coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
+        #print('lenght mni coordinates',len(mni_coords))
+        #xyz_coords = [coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
+        dt_papers_nq, xyz_coords = load_or_calculate_variables(data_path, affine_inv)
 
 
         x_target, y_target, z_target = coord_transform(x_target, y_target, z_target,affine_inv)
@@ -91,4 +95,39 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
     else:
         # Handle the case where none of the conditions are met
         print("Invalid combination of input values. Please check.")
+
+
+def load_or_calculate_variables(data_path, affine_inv):
+    dt_papers_nq_path = os.path.join(data_path, 'dt_papers_nq.pkl')
+    xyz_coords_path = os.path.join(data_path, 'xyz_coords.pkl')
+
+    # Check if the files exist
+    if os.path.exists(dt_papers_nq_path) and os.path.exists(xyz_coords_path):
+        # Load dt_papers_nq
+        with open(dt_papers_nq_path, 'rb') as f:
+            dt_papers_nq = pickle.load(f)
+
+        # Load xyz_coords
+        with open(xyz_coords_path, 'rb') as f:
+            xyz_coords = pickle.load(f)
+    else:
+        # Calculate and save dt_papers_nq
+        dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
+
+        # Calculate the Euclidean distance from each point to the center of the sphere
+        mni_coords = dt_papers_nq[["x", "y", "z"]].values  # assuming this is a list of triplets
+
+        # Convert MNI coordinates to voxel coordinates for each coordinate
+        xyz_coords = [coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords]
+
+        # Save dt_papers_nq
+        with open(dt_papers_nq_path, 'wb') as f:
+            pickle.dump(dt_papers_nq, f)
+
+        # Save xyz_coords
+        with open(xyz_coords_path, 'wb') as f:
+            pickle.dump(xyz_coords, f)
+    
+    return dt_papers_nq, xyz_coords
+
 

--- a/neuroinfer/code/BayesianAnalysis.py
+++ b/neuroinfer/code/BayesianAnalysis.py
@@ -65,9 +65,19 @@ def run_bayesian_analysis_router(cog_list, area, prior_list, x_target, y_target,
         mask,affine=generate_nifit_mask(1,atlas_path) #area is set to 1 to get the mask at the coordinates
         affine_inv = np.linalg.inv(affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
 
+        data_path = os.path.join(global_path, "data")  # Path to the saved_result folder
+        print('Data path: ',data_path)
 
-        x_target, y_target, z_target = image.coord_transform(x_target, y_target, z_target,affine_inv)
-        results=run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, radius, result_df, cm,affine_inv)
+        dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
+        # Calculate the Euclidean distance from each point to the center of the sphere
+        mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
+        # Convert MNI coordinates to voxel coordinates for each coordinate
+        print('lenght mni coordinates',len(mni_coords))
+        xyz_coords = [coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
+
+
+        x_target, y_target, z_target = coord_transform(x_target, y_target, z_target,affine_inv)
+        results=run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, radius, result_df, cm,xyz_coords,dt_papers_nq)
 
         pickle_file_name = f'results_BHL_coordinates_cm_{cm}_x{x_target}_y{y_target}_z{z_target}.pickle'
         pickle_file_path = os.path.join(results_folder_path, pickle_file_name)

--- a/neuroinfer/code/plot_generator.py
+++ b/neuroinfer/code/plot_generator.py
@@ -107,18 +107,10 @@ def main_analyse_and_render(data):
     # Perform Bayesian analysis to obtain coordinates (coords) and Bayesian factor values (bf)
     # The run_bayesian_analysis function takes parameters such as brain_region, words, radius, and priors,
     # and returns the computed coordinates and Bayesian factor values.
-    # # Get the directory of the current Python script
-    # script_directory = os.path.dirname(os.path.abspath(__file__))
-    # # Navigate to the parent directory as global path
-    # global_path = os.path.dirname(script_directory)
-    # data_path = os.path.join(global_path, "data")  # Path to the saved_result folder
     result_df, _ = load_data_and_create_dataframe(DATA_FOLDER / "features7.npz",
                                                   DATA_FOLDER / "metadata7.tsv",
                                                   DATA_FOLDER / "vocabulary7.txt")
     result_dict = run_bayesian_analysis_area(cog_list, prior_list, mask, affine_inv, radius, result_df, 'a')
-
-    # Create a histogram of the obtained coordinates and Bayesian factors
-    # results = create_hist(coords, bf, atlas_target_path)
 
     # Generate a NIfTI heatmap using the coordinates and Bayesian factors
     # The generate_nifti_bf_heatmap function utilizes the coordinates and Bayesian factors
@@ -126,8 +118,6 @@ def main_analyse_and_render(data):
     # the spatial distribution of the Bayesian factor values in the specified brain region.
     overlay_results, filenames = generate_nifti_bf_heatmap(result_dict, atlas_path, radius, cog_list)
 
-    # Creating a bar plot using matplotlib
-    # Flatten all the data
     hist_bins = np.histogram_bin_edges(overlay_results.flatten(), bins=30)
     num_items = overlay_results.shape[-1]
     for i in range(num_items):

--- a/neuroinfer/code/plot_generator.py
+++ b/neuroinfer/code/plot_generator.py
@@ -222,7 +222,7 @@ def generate_nifti_bf_heatmap(result_dict, atlas_target_path, radius, cog_list):
     coords = []
     for sphere in result_dict:
         bf.append(sphere['df_data_all'].BF)
-        coords.append([sphere['x_target'], #TODO: the coords are mni coords
+        coords.append([sphere['x_target'],
                        sphere['y_target'],
                        sphere['z_target'],
                        ])
@@ -236,15 +236,11 @@ def generate_nifti_bf_heatmap(result_dict, atlas_target_path, radius, cog_list):
     counter = np.zeros([*reference_data_shape.shape, len(bf[0])])
 
     # Iterate through the given coordinates and apply the measurements to populate overlay_results
-    mni2vx_mat = np.linalg.inv(reference_data_shape_nifti.affine)
     vx_size = np.abs(reference_data_shape_nifti.affine[0, 0])
     vx_radius = np.ceil(radius/vx_size)
 
     for j, coord in enumerate(coords):
-        vx_coord = nilearn.image.coord_transform(
-            int(coord[0]), int(coord[1]), int(coord[2]), mni2vx_mat
-        )
-        sphere_coords = get_sphere_coords([int(vx_coord[0]), int(vx_coord[1]), int(vx_coord[2])], vx_radius, overlay_results)
+        sphere_coords = get_sphere_coords([int(coord[0]), int(coord[1]), int(coord[2])], vx_radius, overlay_results)
         for sc_i in range(sphere_coords[0].shape[0]):
             overlay_results[sphere_coords[0][sc_i], sphere_coords[1][sc_i], sphere_coords[2][sc_i], :] += bf[j] #TODO: this depends on the type of analysis done!
             for cog_counter in range(len(result_dict[0]['cog_list'])):

--- a/neuroinfer/code/plot_generator.py
+++ b/neuroinfer/code/plot_generator.py
@@ -158,7 +158,7 @@ def main_analyse_and_render(data):
     return response
 
 
-def generate_nifit_mask(region_id, atlas_target_path, smooth_factor):
+def generate_nifit_mask(region_id, atlas_target_path, smooth_factor=0):
     """
     Generate a NIfTI mask based on a specified region ID in an atlas image.
 

--- a/neuroinfer/code/plot_generator.py
+++ b/neuroinfer/code/plot_generator.py
@@ -176,8 +176,13 @@ def generate_nifit_mask(region_id, atlas_target_path, smooth_factor=0):
       modified atlas image as a NIfTI file in the '.tmp/' directory.
     """
 
+    # Check if region_id is a list, if not, convert it to a list
+
+    if type(region_id) != list:
+        region_id = [region_id]    
     # Convert region_id to integer
-    region_id = [np.int32(a) for a in region_id]
+    region_id = [int(i) for i in region_id]
+   
 
     # Load atlas image
     atlas_img = image.load_img(atlas_target_path)

--- a/neuroinfer/code/run_bayesian.py
+++ b/neuroinfer/code/run_bayesian.py
@@ -164,8 +164,6 @@ def get_distance(coord1, coord2):
 def get_atlas_coordinates_json(json_path):
     with open(json_path, 'r') as infile:
         coordinates_atlas = json.load(infile)
-    #for key, coordinates in coordinates_atlas.items():
-        #print(f"Key: {key}, Number of Coordinates: {len(coordinates)}")
 
     return coordinates_atlas
 
@@ -184,8 +182,6 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
     Returns:
     - results: list of BF and coordinates.
     """
-    # Extract coordinates of the specified area from the atlas
-     # Get the script's directory using Path
 
     # Set the global path
     # Get the directory of the current Python script
@@ -197,41 +193,24 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
 
     t_area = time.time()
 
-    # Load mask image
-    #mask_nifti = image.load_img('.tmp/mask.nii.gz')
-    #affine_inv = np.linalg.inv(mask_nifti.affine) #inverse of the affine matrix to convert from MNI coordinates tp voxel coordinates
-    #mask = np.asarray(mask_nifti.get_fdata())
     coordinates_area = np.where(mask == 1)
     coordinates_area = [[coordinates_area[0][a], coordinates_area[1][a], coordinates_area[2][a]] for a in range(len(coordinates_area[0]))] #list of coordinated in the mask with value 1
-
     
     # Initialize an empty list to store results and coordinates
-    #results_dict = {}
     result_all = []
     coord=[]
-
-    #dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
-    # Calculate the Euclidean distance from each point to the center of the sphere
-    #mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
-    # Convert MNI coordinates to voxel coordinates for each coordinate
-    #print('lenght mni coordinates',len(mni_coords))
-    #xyz_coords = [image.coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
     
     # Iterate through the coordinates_area
     for i in range(len(coordinates_area)-1): #-1 in order to have the last coordinates_area[i+1]) #TODO improve
         
         x_target, y_target, z_target = coordinates_area[i]
         coord.append([x_target, y_target, z_target])
-        #print(coord)
-        #print (i)
         if i==0:
-            #result = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, rescaled_radius, feature_df,cm)
             results = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target,
                                                         radius, feature_df, cm,xyz_coords,dt_papers_nq)
             #print(results_dict[i])           
             # Append a tuple containing the BF value and the coordinates to result_with_coordinates
             result_all.append(results)
-        #df_data_all, cm, cog_all, prior_all, x_target, y_target, z_target, radius
 
         # Check if next_coord is distant > rescaled_radius * 0.98 from all previous coordinates
 
@@ -252,9 +231,6 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
 
     elapsed_area = time.time() - t_area
     print(f'Time in min: {round(elapsed_area / 60, 2)}')
-
-    # Plot distribution and statistics of the Bayesian Factor (BF) for the area
-    #plot_distribution_statistics(result_with_coordinates)
 
     print(result_all)
     

--- a/neuroinfer/code/run_bayesian.py
+++ b/neuroinfer/code/run_bayesian.py
@@ -207,10 +207,6 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
     coordinates_area = np.where(mask == 1)
     coordinates_area = [[coordinates_area[0][a], coordinates_area[1][a], coordinates_area[2][a]] for a in range(len(coordinates_area[0]))] #list of coordinated in the mask with value 1
 
-    # Rescale the radius to be between 2 and 4
-    rescaled_radius = max(2, min(radius, 4))
-    print(' rescaled_radius:' ,  rescaled_radius)
-
     
     # Initialize an empty list to store results and coordinates
     #results_dict = {}
@@ -227,7 +223,7 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
         if i==0:
             #result = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, rescaled_radius, feature_df,cm)
             results = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target,
-                                                        rescaled_radius, feature_df, cm, affine_inv)
+                                                        radius, feature_df, cm, affine_inv)
             #print(results_dict[i])           
             # Append a tuple containing the BF value and the coordinates to result_with_coordinates
             result_all.append(results)
@@ -237,7 +233,7 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
 
         # if all(get_distance((x_target, y_target, z_target), coordinate) > rescaled_radius * 0.98 for coordinate in coord):
         if get_distance((x_target, y_target, z_target), coordinates_area[
-            i + 1]) > rescaled_radius:  # TODO upload checking all the distance from the ROIS
+            i + 1]) > radius:  # TODO upload checking all the distance from the ROIS
             print(
                 f'Calculating cm for the {i + 1} ROI out of {len(coordinates_area)}, {((i + 1) / len(coordinates_area)) * 100}% ')
             if i % 10 == 0:
@@ -245,7 +241,7 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
                     f_tmp.write(str((i + 1) / len(coordinates_area)))
             print(get_distance((x_target, y_target, z_target), coordinates_area[i + 1]))
             # Call run_bayesian_analysis_coordinates with the current coordinates
-            results = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, rescaled_radius, feature_df, cm, affine_inv)
+            results = run_bayesian_analysis_coordinates(cog_list, prior_list, x_target, y_target, z_target, radius, feature_df, cm, affine_inv)
             # Append a tuple containing the BF value and the coordinates to result_with_coordinates
             result_all.append(results)
 

--- a/neuroinfer/code/run_bayesian.py
+++ b/neuroinfer/code/run_bayesian.py
@@ -170,7 +170,7 @@ def get_atlas_coordinates_json(json_path):
     return coordinates_atlas
 
 #
-def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, feature_df,cm):
+def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, feature_df,cm,dt_papers_nq,xyz_coords):
     """
     Perform Bayesian analysis in a specified area using coordinates from the atlas.
 
@@ -210,12 +210,12 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
     result_all = []
     coord=[]
 
-    dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
+    #dt_papers_nq = pd.read_csv(os.path.join(data_path, 'data-neurosynth_version-7_coordinates.tsv'), sep='\t')
     # Calculate the Euclidean distance from each point to the center of the sphere
-    mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
+    #mni_coords = dt_papers_nq[["x", "y", "z"]].values #assuming this is a list of triplets
     # Convert MNI coordinates to voxel coordinates for each coordinate
-    print('lenght mni coordinates',len(mni_coords))
-    xyz_coords = [image.coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
+    #print('lenght mni coordinates',len(mni_coords))
+    #xyz_coords = [image.coord_transform(a[0], a[1], a[2], affine_inv) for a in mni_coords] 
     
     # Iterate through the coordinates_area
     for i in range(len(coordinates_area)-1): #-1 in order to have the last coordinates_area[i+1]) #TODO improve
@@ -236,10 +236,9 @@ def run_bayesian_analysis_area(cog_list, prior_list, mask,affine_inv, radius, fe
         # Check if next_coord is distant > rescaled_radius * 0.98 from all previous coordinates
 
         # if all(get_distance((x_target, y_target, z_target), coordinate) > rescaled_radius * 0.98 for coordinate in coord):
-        if get_distance((x_target, y_target, z_target), coordinates_area[
-            i + 1]) > radius:  # TODO upload checking all the distance from the ROIS
-            print(
-                f'Calculating cm for the {i + 1} ROI out of {len(coordinates_area)}, {((i + 1) / len(coordinates_area)) * 100}% ')
+        if get_distance((x_target, y_target, z_target), coordinates_area[i + 1]) > radius:  # TODO upload checking all the distance from the ROIS
+            print(f'Calculating cm for the {i + 1} ROI out of {len(coordinates_area)}, {((i + 1) / len(coordinates_area)) * 100:.2f}%')
+
             if i % 10 == 0:
                 #create the folder if not existing
                 os.makedirs(PKG_FOLDER / 'neuroinfer' / '.tmp', exist_ok=True)                


### PR DESCRIPTION
The functions `run_bayesian_analysis_router`, `area`, and `coordinates` have been modified to utilize `dt_papers_nq` and `xyz_coords`, which are calculated by the `load_or_calculate_variables` function from the `data-neurosynth_version-7_coordinates.tsv` file and affine matrices. In the case of `area`, it is `mask, affine = generate_nifit_mask(area, atlas_path)`.

For `coordinates`, it is `mask, affine = generate_nifit_mask(1, atlas_path)`. 

The time taken to obtain the results has been significantly reduced.